### PR TITLE
add tasks and templates for opening UDP ports

### DIFF
--- a/tasks/ferm_allow_global_udp_port.yml
+++ b/tasks/ferm_allow_global_udp_port.yml
@@ -1,0 +1,6 @@
+- name: allow all incoming connections on UDP port {{port}}
+  tags: firewall
+  template: src=../templates/ferm_allow_global_udp_port.conf.j2
+            dest=/etc/ferm/ferm.d/allow-{{port}}-udp.conf
+  notify:
+    - reload firewall

--- a/tasks/ferm_allow_local_udp_port.yml
+++ b/tasks/ferm_allow_local_udp_port.yml
@@ -1,0 +1,6 @@
+- name: local port rule {{name}} - allow connections on UDP port {{port}} from {{src}}
+  tags: firewall
+  template: src=../templates/ferm_allow_local_udp_port.conf.j2
+            dest=/etc/ferm/ferm.d/{{name}}-udp.conf
+  notify:
+    - reload firewall

--- a/templates/ferm_allow_global_udp_port.conf.j2
+++ b/templates/ferm_allow_global_udp_port.conf.j2
@@ -1,0 +1,1 @@
+proto udp dport {{port}} ACCEPT;

--- a/templates/ferm_allow_local_dup_port.conf.j2
+++ b/templates/ferm_allow_local_dup_port.conf.j2
@@ -1,0 +1,1 @@
+saddr {{src}} proto udp dport {{port}} ACCEPT;


### PR DESCRIPTION
UDP ports are necessary for consul, among, perhaps, other things.
